### PR TITLE
Remove misformated links

### DIFF
--- a/output/scraperResults/adam-sandler.json
+++ b/output/scraperResults/adam-sandler.json
@@ -102,8 +102,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_3_304",
-      "sourceTitle": "↩",
       "text": "Again, politics or the advancement of society isn't a topic Sandler likes to talk about. His expertise lies mostly in dick and fart jokes. But he is a registered Republican, which is uncharacteristic for a Jew and is even somewhat active in the party."
     },
     {

--- a/output/scraperResults/drake.json
+++ b/output/scraperResults/drake.json
@@ -76,8 +76,6 @@
     },
     {
       "type": "quote",
-      "sourceUrl": "#identifier_2_260",
-      "sourceTitle": "↩",
       "text": "At the end of the day, I consider myself a black man because I'm more immersed in black culture than any other."
     },
     {

--- a/output/scraperResults/elizabeth-banks.json
+++ b/output/scraperResults/elizabeth-banks.json
@@ -71,8 +71,6 @@
     },
     {
       "type": "quote",
-      "sourceUrl": "#identifier_2_7768",
-      "sourceTitle": "↩",
       "text": "No religion meant as much to me as Judaism meant to my husband."
     },
     {

--- a/output/scraperResults/emily-rose.json
+++ b/output/scraperResults/emily-rose.json
@@ -50,8 +50,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_1_8473",
-      "sourceTitle": "↩",
       "text": "And, going along with the theme, she also talks about being blessed quite a bit."
     },
     {

--- a/output/scraperResults/emmy-rossum.json
+++ b/output/scraperResults/emmy-rossum.json
@@ -142,8 +142,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_12_10667",
-      "sourceTitle": "↩",
       "text": "and she works with several non-profit organizations to promote awareness of environmental issues."
     },
     {

--- a/output/scraperResults/jon-stewart.json
+++ b/output/scraperResults/jon-stewart.json
@@ -138,8 +138,6 @@
     },
     {
       "type": "quote",
-      "sourceUrl": "#identifier_4_145",
-      "sourceTitle": "↩",
       "text": "Stewart: I've got some conservative views.\nGospel choir: He's a pro-military motherfucker. Peace to the troops.\nStewart: I've got some libertarian views.\nGospel choir: Legalize it.\nStewart: Gay marriage! Pot! Gay pot marriage!\nGospel choir: Amen!\nStewart: And I believe this country should provide some kind of social safety net for some of our most vulnerable citizens.\nGospel choir: Communist."
     }
   ],

--- a/output/scraperResults/lucy-hale.json
+++ b/output/scraperResults/lucy-hale.json
@@ -129,8 +129,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_8_5732",
-      "sourceTitle": "↩",
       "text": "But that's about it on Hale's political involvement. She's involved in a couple of charitable organizations that help improve the lives of kids in foster care"
     },
     {

--- a/output/scraperResults/madonna.json
+++ b/output/scraperResults/madonna.json
@@ -54,8 +54,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_2_99",
-      "sourceTitle": "↩",
       "text": "She has even, at times been asked to be called Esther, after the Jewish historical figure."
     },
     {

--- a/output/scraperResults/mitt-romney.json
+++ b/output/scraperResults/mitt-romney.json
@@ -44,8 +44,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_1_93",
-      "sourceTitle": "↩",
       "text": "Romney even donated over $4 million to the Mormon church over the last 5 years."
     },
     {
@@ -103,8 +101,6 @@
     },
     {
       "type": "sentence",
-      "sourceUrl": "#identifier_5_93",
-      "sourceTitle": "↩",
       "text": "During his second campaign, he tried to pass himself off as ultra conservative and is even slamming Obama's adding contraceptives to health insurance plans."
     },
     {

--- a/output/scraperResults/shakira.json
+++ b/output/scraperResults/shakira.json
@@ -145,8 +145,6 @@
     },
     {
       "type": "quote",
-      "sourceUrl": "#identifier_8_1541",
-      "sourceTitle": "↩",
       "text": "How does politics work? It's shit!"
     },
     {

--- a/src/lib/scrape.ts
+++ b/src/lib/scrape.ts
@@ -71,9 +71,11 @@ function scrapeText($: CheerioStatic, e: CheerioElement) {
           .find(id)
           .find('a:first-of-type');
 
-        sourceUrl = $a.attr('href');
-        sourceTitle = $a.text() || undefined;
-
+        const href = $a.attr('href');
+        if (!href.startsWith('#')) {
+          sourceUrl = href;
+          sourceTitle = $a.text() || undefined;
+        }
         content.push({ text, sourceUrl, sourceTitle });
         sourceUrl = undefined;
         sourceTitle = undefined;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,8 +5,5 @@
     "checkJs": false,
     "maxNodeModuleJsDepth": 0,
     "outDir": "../dist"
-  },
-  "exclude": [
-    "node_modules"
-  ]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "./node_modules/@hollowverse/common/tsconfig.json",
   "exclude": [
-    "dist",
-    "node_modules"
+    "dist"
   ]
 }


### PR DESCRIPTION
During an attempt to import the scraper data into the database, validation of some URLs failed. It turns out some pages on the old website had some misformatted links. I fixed the scraper to handle that issue.